### PR TITLE
make clean error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ $(TARGET): xcape.c
 
 install:
 	$(INSTALL) -Dm 755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
+	$(INSTALL) -Dm 644 ksuperkey.desktop $(DESTDIR)$(PREFIX)/share/autostart/ksuperkey.desktop
 
 clean:
 	if [ -e $(TARGET) ]; then rm $(TARGET); fi

--- a/ksuperkey.desktop
+++ b/ksuperkey.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Exec=ksuperkey
+X-DBUS-StartupType=none
+Name=ksuperkey
+Type=Service
+X-KDE-StartupNotify=false
+OnlyShowIn=KDE;
+X-KDE-autostart-phase=2


### PR DESCRIPTION
If directory is already cleaned, `make clean' return error. It is important for me because I try to build .deb package with debhelper.
