### PR TITLE
Prevent make clean from failing when the file to remove does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,6 @@ uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/share/autostart/ksuperkey.desktop
 
 clean:
-	if [ -e $(TARGET) ]; then rm $(TARGET); fi
+	if [ -e $(TARGET) ]; then rm -f $(TARGET); fi
 
 .PHONY: clean


### PR DESCRIPTION
Well, I never realized I would change something here but with my maintainer hat on I can fully say I don't want my package to fail building on make clean.

Could you make a release with this change so I can package that for Debian/Ubuntu?