### PR TITLE
Improve usability of ksuperkey.desktop file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 INSTALL=install
 PREFIX=/usr
+AUTOSTART=/etc/xdg/autostart
 
 TARGET := ksuperkey
+DESKTOP := ksuperkey.desktop
 
 CFLAGS += -Wall
 CFLAGS += `pkg-config --cflags xtst x11`
@@ -16,9 +18,12 @@ $(TARGET): xcape.c
 install:
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(PREFIX)/bin/$(TARGET)
+	$(INSTALL) -d -m 0755 $(DESTDIR)$(AUTOSTART)
+	$(INSTALL) -m 0644 $(DESKTOP) $(DESTDIR)$(AUTOSTART)/$(DESKTOP)
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/$(TARGET)
+	rm -f $(DESTDIR)$(PREFIX)$(AUTOSTART)/$(DESKTOP)
 
 clean:
 	if [ -e $(TARGET) ]; then rm $(TARGET); fi

--- a/ksuperkey.desktop
+++ b/ksuperkey.desktop
@@ -2,7 +2,7 @@
 Exec=ksuperkey
 X-DBUS-StartupType=none
 Name=ksuperkey
-Type=Service
+Type=Application
 X-KDE-StartupNotify=false
-OnlyShowIn=KDE;
+OnlyShowIn=KDE;XFCE;
 X-KDE-autostart-phase=2


### PR DESCRIPTION
Two changes in this PR:
 * Automatically install the `.desktop` file in `/etc/xdg/autostart` on `make install`, so that this command will actually enable ksuperkey.
 * Change the `.desktop` file to work in more than just KDE

I can understand if you want me to separate this PR into the two commits, or make one with just one or the other, but I think both are useful.