### PR TITLE
Make desktop file work in other desktop environments

### DIFF
--- a/ksuperkey.desktop
+++ b/ksuperkey.desktop
@@ -2,7 +2,6 @@
 Exec=ksuperkey
 X-DBUS-StartupType=none
 Name=ksuperkey
-Type=Service
+Type=Application
 X-KDE-StartupNotify=false
-OnlyShowIn=KDE;
 X-KDE-autostart-phase=2


### PR DESCRIPTION
As suggested in #20, I removed the `OnlyShowIn=` line entirely.